### PR TITLE
Fixing broken tutorial

### DIFF
--- a/.github/workflows/continous-deployment.yml
+++ b/.github/workflows/continous-deployment.yml
@@ -77,8 +77,8 @@ jobs:
       - name: Configure SSH
         run: |
           mkdir -p ~/.ssh/
-          echo "$SSH_KEY" > ~/.ssh/minitwit.key
-          chmod 600 ~/.ssh/minitwit.key
+          echo "$SSH_KEY" > ~/.ssh/do_ssh_key
+          chmod 600 ~/.ssh/do_ssh_key
         env:
           SSH_KEY: ${{ secrets.SSH_KEY }}
 
@@ -86,7 +86,7 @@ jobs:
         # Configure the ~./bash_profile and deploy.sh file on the Vagrantfile
         run: >
           ssh $SSH_USER@$SSH_HOST
-          -i ~/.ssh/minitwit.key -o StrictHostKeyChecking=no
+          -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no
           '/minitwit/deploy.sh'
         env:
           SSH_USER: ${{ secrets.SSH_USER }}

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ ssh-keygen -f ~/.ssh/do_ssh_key -t rsa -b 4096 -m "PEM"
 
 Hit enter two times to accept the proposed defaults.
 You can call the SSH key files whatever you want, but the `Vagrantfile` expects the SSH keys to have that specific name.
-So in case you use another name, adapt the `Vagrantfile` accordingly (line `provider.ssh_key_name = "do_ssh_key"`).
+So in case you use another name, adapt the `Vagrantfile` accordingly (line `provider.ssh_key_name = "do_ssh_key"`). Additionally for Step 4, you must change it all 3 times it is being defined in in `.github/workflows/continous-deployment.yml`
 
 
 ### Step 1.b) Register your Public SSH at DigitalOcean


### PR DESCRIPTION
There is an inconsistency in how the workflow expects the ssh keys to be named and how the tutorial walks you through it. This fixes the Action as well as updating the README.md to inform people about this variable. 