### PR TITLE
Fix workflow docker compose error and update actions

### DIFF
--- a/.github/workflows/continous-deployment.yml
+++ b/.github/workflows/continous-deployment.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Test minitwit
         run: |
           docker build -t $DOCKER_USERNAME/minitwittestimage -f Dockerfile-minitwit-tests .
-          yes 2>/dev/null | docker-compose up -d
+          yes 2>/dev/null | docker compose up -d
           docker run --rm --network=itu-minitwit-network $DOCKER_USERNAME/minitwittestimage
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/continous-deployment.yml
+++ b/.github/workflows/continous-deployment.yml
@@ -28,16 +28,16 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push minitwitimage
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile-minitwit
@@ -47,7 +47,7 @@ jobs:
           cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/minitwitimage:webbuildcache,mode=max
 
       - name: Build and push mysqlimage
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile-mysql
@@ -57,7 +57,7 @@ jobs:
           cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/mysqlimage:mysqlbuildcache,mode=max
 
       - name: Build and push flagtoolimage
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile-flagtool


### PR DESCRIPTION
The workflow currently uses `docker-compose` with a dash, which is no longer available, the new syntax is `docker compose`. 
The docker actions used are also outdated and use the `save-state` command for Github actions is deprecated and will be disabled soon.